### PR TITLE
Support VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ lspwatch_metrics.json
 go.work
 **/build/
 **/coverage
+stubs

--- a/README.md
+++ b/README.md
@@ -98,8 +98,6 @@ gopls = {
 ```
 </details>
 
-<br/>
-
 <details>
 <summary><b>(Golang) VSCode + vscode-go</code></b></summary>
 <br/>

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ TODO
 
 ## Usage
 
-`lspwatch` is an executable that transparently stands in place of the language server. `lspwatch` operates in 2 one of two modes:
+`lspwatch` is an executable that transparently stands in place of the language server. `lspwatch` operates in one of two modes:
 
 1. **`command` mode**: For running one-time language server queries like `gopls stats`, where the command exits after returning results. Editors often use such queries to gather static metadata.
 2. **`proxy` mode**: For long-running language server sessions where LSP messages are continuously exchanged. This is the  typical usage of the language server.

--- a/README.md
+++ b/README.md
@@ -69,11 +69,42 @@ TODO
 
 ## Usage
 
-`lspwatch` is an executable that stands in place of the language server. If your language server is invoked using e.g `clangd ...`, then you can run `lspwatch -- clangd ...`.
+`lspwatch` is an executable that transparently stands in place of the language server. `lspwatch` operates in 2 one of two modes:
 
-Every editor that supports LSP will have a way to configure the  command used to invoke the language server. Reference the documenation of your editor or language extension for details.
+1. **`command` mode**: For running one-time language server queries like `gopls stats`, where the command exits after returning results. Editors often use such queries to gather static metadata.
+2. **`proxy` mode**: For long-running language server sessions where LSP messages are continuously exchanged. This is the  typical usage of the language server.
 
-TODO: Show examples.
+`lspwatch` will automatically choose the correct mode, but you can also specify it using the `--mode` flag (e.g `lspwatch --mode command -- gopls stats`).
+
+Generally, to use `lpswatch` for instrumenting your language server, you will need to replace the command your code editor invokes when running the language server. For example, instead of running `gopls <args>`, your editor should run `lspwatch -- gopls <args>`. Most LSP-equipped editors will have a way to configure this. Some examples are included below, but reference the documentation of your editor or language extension for instructions.
+
+<details>
+<summary><b>(Golang) Neovim + <code>nvim-lspconfig</code></b></summary>
+<br/>
+
+`/path/to/instrumented_gopls`:
+```bash
+#!/bin/bash
+lspwatch -- gopls "$@"
+```
+
+`init.lua`:
+```lua
+gopls = {
+  cmd = {
+    "/path/to/instrumented_gopls"
+  }
+}
+```
+</details>
+
+<br/>
+
+<details>
+<summary><b>(Golang) VSCode + vscode-go</code></b></summary>
+<br/>
+TODO
+</details>
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ TODO
 
 `lspwatch` will automatically choose the correct mode, but you can also specify it using the `--mode` flag (e.g `lspwatch --mode command -- gopls stats`).
 
-Generally, to use `lpswatch` for instrumenting your language server, you will need to replace the command your code editor invokes when running the language server. For example, instead of running `gopls <args>`, your editor should run `lspwatch -- gopls <args>`. Most LSP-equipped editors will have a way to configure this. Some examples are included below, but reference the documentation of your editor or language extension for instructions.
+Generally, to use `lpswatch` for instrumenting your language server, you will need to replace the command your code editor invokes when running the language server. For example, instead of running `gopls <args>`, your editor should run `lspwatch -- gopls <args>`. Most LSP-equipped editors will have a way to configure this. Some verified examples are included below, but reference the documentation of your editor or language extension for instructions.
 
 <details>
 <summary><b>(Golang) Neovim + <code>nvim-lspconfig</code></b></summary>
@@ -103,7 +103,21 @@ gopls = {
 <details>
 <summary><b>(Golang) VSCode + vscode-go</code></b></summary>
 <br/>
-TODO
+
+`/path/to/instrumented_gopls`:
+```bash
+#!/bin/bash
+lspwatch -- gopls "$@"
+```
+
+`.vscode/settings.json`:
+```json
+{
+    "go.alternateTools": {
+        "gopls": "/path/to/instrumented_gopls"
+    }
+}
+```
 </details>
 
 ## Configuration

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,7 +30,6 @@ var rootCmd = &cobra.Command{
 		}
 
 		lspwatchInstance, err := internal.NewLspwatchInstance(args[0], serverArgs, configFilePath, logDir, mode)
-
 		if err != nil {
 			fmt.Printf("error setting up lspwatch: %v\n", err)
 			os.Exit(1)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,8 @@ import (
 
 var configFilePath string
 var logDir string
+var mode string
+
 var rootCmd = &cobra.Command{
 	Use:   "lspwatch",
 	Short: "lspwatch provides observability for LSP-compliant language servers over stdin/stdout",
@@ -27,7 +29,7 @@ var rootCmd = &cobra.Command{
 			serverArgs = []string{}
 		}
 
-		lspwatchInstance, err := internal.NewLspwatchInstance(args[0], serverArgs, configFilePath, logDir)
+		lspwatchInstance, err := internal.NewLspwatchInstance(args[0], serverArgs, configFilePath, logDir, mode)
 
 		if err != nil {
 			fmt.Printf("error setting up lspwatch: %v\n", err)
@@ -48,4 +50,5 @@ func Execute() {
 func init() {
 	rootCmd.PersistentFlags().StringVar(&configFilePath, "config", "", "path to config file for lspwatch")
 	rootCmd.PersistentFlags().StringVar(&logDir, "logdir", "", "path to log directory for lspwatch")
+	rootCmd.PersistentFlags().StringVar(&mode, "mode", "", "lpswatch mode (`command` or `proxy`)")
 }

--- a/internal/core/proxy.go
+++ b/internal/core/proxy.go
@@ -102,8 +102,8 @@ func (ph *ProxyHandler) Start() {
 		go ph.passThroughServerBytes()
 	}
 
-	// Unless command mode is explicitly set, the proxy handler will process
-	// client data as LSP messages.
+	// Unless command mode is explicitly set, the proxy handler will begin
+	// processing client data as LSP messages.
 	if ph.mode != "command" {
 		ph.listenersWaitGroup.Add(1)
 		go ph.listenClient()
@@ -237,7 +237,7 @@ func (ph *ProxyHandler) listenServer() {
 									duration.Seconds(),
 									telemetry.NewTag("method", telemetry.TagValue(requestBookmark.Method)),
 								)
-								ph.logger.Infof("emitting metric '%s'", requestDurationMetric.Name)
+								ph.logger.Infof("emitting metric %q", requestDurationMetric.Name)
 								err := ph.metricsRegistry.EmitMetric(requestDurationMetric)
 								if err != nil {
 									ph.logger.Errorf("error emitting metric: %v", err)
@@ -246,7 +246,7 @@ func (ph *ProxyHandler) listenServer() {
 						}
 					} else {
 						ph.logger.Infof(
-							"received client response for unbuffered request with ID=%v",
+							"received client response for unbuffered request with ID=%q",
 							serverMessage.Id.Value,
 						)
 					}
@@ -373,7 +373,6 @@ func (ph *ProxyHandler) listenClient() {
 
 func (ph *ProxyHandler) switchToProxyModeOnce() {
 	ph.switchOnce.Do(func() {
-		// TODO: Caller should do this?
 		ph.logger.Info("switching proxy handler to proxy mode")
 		// Stop pass-through of server bytes.
 		ph.serverPassThroughWriter.Close()

--- a/internal/core/proxy.go
+++ b/internal/core/proxy.go
@@ -161,7 +161,7 @@ func (ph *ProxyHandler) listenServer() {
 		if err != nil {
 			ph.logger.Errorf("error closing reader for server input: %v", err)
 		}
-		// TODO: IMO, closing the outputToClient writer should be done in the caller, not here
+		// TODO: IMO, closing the outputToClient writer should be done in the caller, not here.
 		err = ph.outputToClient.Close()
 		if err != nil {
 			ph.logger.Errorf("error closing writer for client output: %v", err)
@@ -276,7 +276,7 @@ func (ph *ProxyHandler) listenClient() {
 		if err != nil {
 			ph.logger.Errorf("error closing reader for client input: %v", err)
 		}
-		// TODO: IMO, closing the outputToServer writer should be done in the caller, not here
+		// TODO: IMO, closing the outputToServer writer should be done in the caller, not here.
 		err = ph.outputToServer.Close()
 		if err != nil {
 			ph.logger.Errorf("error closing writer for server output: %v", err)
@@ -385,7 +385,6 @@ func (ph *ProxyHandler) switchToProxyModeOnce() {
 	})
 }
 
-// TODO: Take a single struct argument because this is a mess now.
 func NewProxyHandler(
 	cfg *config.LspwatchConfig,
 	metricsRegistry telemetry.MetricsRegistry,

--- a/internal/core/watcher.go
+++ b/internal/core/watcher.go
@@ -25,7 +25,6 @@ type ProcessWatcher struct {
 	pollingInterval time.Duration
 	processExited   bool
 
-	// TODO Change to a channel of int (exit code)
 	processExitedChan chan *os.ProcessState
 	incomingShutdown  chan struct{}
 	logger            *logrus.Logger

--- a/internal/core/watcher.go
+++ b/internal/core/watcher.go
@@ -33,12 +33,12 @@ type ProcessWatcher struct {
 }
 
 func (pw *ProcessWatcher) Start(processHandle ProcessHandle, processInfo ProcessInfo) error {
-	// I'm ok with letting this goroutine run indefinitely (for now)
+	// I'm ok with letting this goroutine run indefinitely (for now).
 	go func() {
 		state, err := processHandle.Wait()
 		if err != nil {
-			// TODO: Should I just os.Exit here?
-			pw.logger.Errorf("error waiting for process to exit: %v", err)
+			pw.logger.Errorf("fatal error waiting for process to exit: %v", err)
+			os.Exit(1)
 		}
 
 		pw.mu.Lock()

--- a/internal/core/watcher_test.go
+++ b/internal/core/watcher_test.go
@@ -66,15 +66,13 @@ func (m *mockProcessInfo) MemoryInfo() (*process.MemoryInfoStat, error) {
 }
 
 func TestNewProcessWatcher(t *testing.T) {
-	processHandle := mockProcessHandle{}
-	processInfo := mockProcessInfo{}
 	logger := logrus.New()
 	logger.SetOutput(io.Discard)
 	t.Run("no configured metrics", func(t *testing.T) {
 		t.Parallel()
 		metricsRegistry := mockWatcherMetricsRegistry{}
 		cfg := config.LspwatchConfig{}
-		_, err := NewProcessWatcher(&processHandle, &processInfo, &metricsRegistry, &cfg, logger)
+		_, err := NewProcessWatcher(&metricsRegistry, &cfg, logger)
 		if err != nil {
 			t.Fatalf("expected no errors creating process watcher, got '%v'", err)
 		}
@@ -94,7 +92,7 @@ func TestNewProcessWatcher(t *testing.T) {
 		cfg := config.LspwatchConfig{
 			Metrics: &[]string{},
 		}
-		_, err := NewProcessWatcher(&processHandle, &processInfo, &metricsRegistry, &cfg, logger)
+		_, err := NewProcessWatcher(&metricsRegistry, &cfg, logger)
 		if err != nil {
 			t.Fatalf("expected no errors creating process watcher, got '%v'", err)
 		}
@@ -111,7 +109,7 @@ func TestNewProcessWatcher(t *testing.T) {
 		cfg := config.LspwatchConfig{
 			Metrics: &[]string{metricName},
 		}
-		_, err := NewProcessWatcher(&processHandle, &processInfo, &metricsRegistry, &cfg, logger)
+		_, err := NewProcessWatcher(&metricsRegistry, &cfg, logger)
 		if err != nil {
 			t.Fatalf("expected no errors creating process watcher, got '%v'", err)
 		}
@@ -138,12 +136,12 @@ func TestProcessWatcher(t *testing.T) {
 		cfg := config.LspwatchConfig{
 			PollingInterval: &pollingIntervalSeconds,
 		}
-		processWatcher, err := NewProcessWatcher(&processHandle, &processInfo, &metricsRegistry, &cfg, logger)
+		processWatcher, err := NewProcessWatcher(&metricsRegistry, &cfg, logger)
 		if err != nil {
 			t.Fatalf("expected no errors creating process watcher, got '%v'", err)
 		}
 
-		err = processWatcher.Start()
+		err = processWatcher.Start(&processHandle, &processInfo)
 		if err != nil {
 			t.Fatalf("expected no errors starting process watcher, got '%v'", err)
 		}
@@ -179,12 +177,12 @@ func TestProcessWatcher(t *testing.T) {
 		cfg := config.LspwatchConfig{
 			PollingInterval: &pollingIntervalSeconds,
 		}
-		processWatcher, err := NewProcessWatcher(&processHandle, &processInfo, &metricsRegistry, &cfg, logger)
+		processWatcher, err := NewProcessWatcher(&metricsRegistry, &cfg, logger)
 		if err != nil {
 			t.Fatalf("expected no errors creating process watcher, got '%v'", err)
 		}
 
-		err = processWatcher.Start()
+		err = processWatcher.Start(&processHandle, &processInfo)
 		if err != nil {
 			t.Fatalf("expected no errors starting process watcher, got '%v'", err)
 		}

--- a/internal/core/watcher_test.go
+++ b/internal/core/watcher_test.go
@@ -30,7 +30,6 @@ var _ telemetry.MetricsRegistry = &mockWatcherMetricsRegistry{}
 var _ ProcessHandle = &mockProcessHandle{}
 var _ ProcessInfo = &mockProcessInfo{}
 
-// TODO all mocks
 func (m *mockWatcherMetricsRegistry) EnableMetric(metric telemetry.AvailableMetric) error {
 	m.enableMetricCalls = append(m.enableMetricCalls, metric)
 	return nil

--- a/internal/core/watcher_test.go
+++ b/internal/core/watcher_test.go
@@ -59,6 +59,10 @@ func (m *mockProcessHandle) kill() {
 	close(m.done)
 }
 
+func (m *mockProcessHandle) ExitCode() int {
+	return 0
+}
+
 func (m *mockProcessInfo) MemoryInfo() (*process.MemoryInfoStat, error) {
 	return &process.MemoryInfoStat{
 		RSS: 1000,

--- a/internal/exporters/datadog.go
+++ b/internal/exporters/datadog.go
@@ -19,7 +19,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// TODO: Make these configurable.
 const defaultBatchSize = 100
 const defaultBatchTimeout = 30 * time.Second
 

--- a/internal/exporters/datadog_test.go
+++ b/internal/exporters/datadog_test.go
@@ -394,7 +394,7 @@ func TestDatadogMetricsExporter(t *testing.T) {
 
 		metricsExporter.Start()
 
-		for i := 0; i < batchSize; i++ {
+		for range batchSize {
 			metricsExporter.EmitMetric(
 				telemetry.NewMetricRecording(
 					"test.metric",

--- a/internal/integration/start_exit_test.go
+++ b/internal/integration/start_exit_test.go
@@ -33,6 +33,7 @@ func TestInvalidCommand(t *testing.T) {
 }
 
 func TestBadConfigFile(t *testing.T) {
+	// TODO: Check logs.
 	t.Run("unreadable config file", func(t *testing.T) {
 		t.Parallel()
 		logDir := testutil.GenerateRandomLogDirName()
@@ -60,6 +61,7 @@ func TestBadConfigFile(t *testing.T) {
 		}
 	})
 
+	// TODO: Check logs.
 	t.Run("nonexistent env file", func(t *testing.T) {
 		t.Parallel()
 		logDir := testutil.GenerateRandomLogDirName()
@@ -91,7 +93,16 @@ func TestBadConfigFile(t *testing.T) {
 func TestServerProcessDiesAbruptly(t *testing.T) {
 	t.Parallel()
 	logDir := testutil.GenerateRandomLogDirName()
-	cmd := testutil.PrepareIntegrationTest(t, "--logdir", logDir, "--", "sleep", "5")
+	cmd := testutil.PrepareIntegrationTest(
+		t,
+		"--logdir",
+		logDir,
+		"--mode",
+		"proxy",
+		"--",
+		"sleep",
+		"5",
+	)
 
 	err := cmd.Start()
 	if err != nil {
@@ -118,7 +129,14 @@ func TestServerProcessDiesAbruptly(t *testing.T) {
 func TestUnresponsiveServerProcess(t *testing.T) {
 	t.Parallel()
 	logDir := testutil.GenerateRandomLogDirName()
-	cmd := testutil.PrepareIntegrationTest(t, "--logdir", logDir, "--", "./build/unresponsive_server")
+	cmd := testutil.PrepareIntegrationTest(t,
+		"--logdir",
+		logDir,
+		"--mode",
+		"proxy",
+		"--",
+		"./build/unresponsive_server",
+	)
 
 	serverStdin, err := cmd.StdinPipe()
 	if err != nil {

--- a/internal/integration/start_exit_test.go
+++ b/internal/integration/start_exit_test.go
@@ -90,6 +90,47 @@ func TestBadConfigFile(t *testing.T) {
 	})
 }
 
+func TestInvalidMode(t *testing.T) {
+	t.Parallel()
+	logDir := testutil.GenerateRandomLogDirName()
+	// No language server command provided.
+	cmd := testutil.PrepareIntegrationTest(
+		t,
+		"--logdir",
+		logDir,
+		"--mode",
+		"invalid_mode",
+		"--",
+		"sleep",
+		"5",
+	)
+	err := cmd.Start()
+	if err != nil {
+		t.Fatalf("error starting lspwatch: %v", err)
+	}
+
+	testutil.AssertExitsBefore(t, "lspwatch", func() {
+		cmd.Process.Wait()
+	}, 3*time.Second)
+
+	if cmd.ProcessState.ExitCode() == 0 {
+		t.Error("expected non-zero exit code")
+	}
+
+	time.Sleep(2 * time.Second)
+
+	fileBytes, err := os.ReadFile(filepath.Join(logDir, "lspwatch.log"))
+	if err != nil {
+		t.Fatalf("error reading lspwatch.log: %v", err)
+	}
+
+	ok := bytes.Contains(fileBytes, []byte("invalid mode: 'invalid_mode'"))
+	if !ok {
+		t.Log(string(fileBytes))
+		t.Fatalf("expected log message \"invalid mode: 'invalid_mode'\" not found in lspwatch.log")
+	}
+}
+
 func TestServerProcessDiesAbruptly(t *testing.T) {
 	t.Parallel()
 	logDir := testutil.GenerateRandomLogDirName()
@@ -188,4 +229,84 @@ func TestUnresponsiveServerProcess(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected log message 'organic language server shutdown failed. forcing with SIGKILL...' not found in lspwatch.log")
 	}
+}
+
+func TestCommandMode(t *testing.T) {
+	t.Run("explicit mode", func(t *testing.T) {
+		t.Parallel()
+		logDir := testutil.GenerateRandomLogDirName()
+		cmd := testutil.PrepareIntegrationTest(
+			t,
+			"--logdir",
+			logDir,
+			"--mode",
+			"command",
+			"--",
+			"echo",
+			"-n", // Suppress newline in output.
+			"integration",
+		)
+
+		serverStdout, err := cmd.StdoutPipe()
+		if err != nil {
+			t.Fatalf("failed to create stdout pipe: %v", err)
+		}
+
+		err = cmd.Start()
+		if err != nil {
+			t.Fatalf("error starting lspwatch: %v", err)
+		}
+
+		buf := make([]byte, 100)
+		n, err := serverStdout.Read(buf)
+		if err != nil {
+			t.Fatalf("error reading stdout: %v", err)
+		}
+
+		if string(buf[:n]) != "integration" {
+			t.Errorf("expected 'integration' in command stdout but found '%s'", string(buf[:n]))
+		}
+
+		testutil.AssertExitsBefore(t, "lspwatch", func() {
+			cmd.Process.Wait()
+		}, 6*time.Second)
+	})
+
+	t.Run("automatic commmand mode detection", func(t *testing.T) {
+		t.Parallel()
+		logDir := testutil.GenerateRandomLogDirName()
+		cmd := testutil.PrepareIntegrationTest(
+			t,
+			"--logdir",
+			logDir,
+			"--",
+			"echo",
+			"-n", // Suppress newline in output.
+			"integration",
+		)
+
+		serverStdout, err := cmd.StdoutPipe()
+		if err != nil {
+			t.Fatalf("failed to create stdout pipe: %v", err)
+		}
+
+		err = cmd.Start()
+		if err != nil {
+			t.Fatalf("error starting lspwatch: %v", err)
+		}
+
+		buf := make([]byte, 100)
+		n, err := serverStdout.Read(buf)
+		if err != nil {
+			t.Fatalf("error reading stdout: %v", err)
+		}
+
+		if string(buf[:n]) != "integration" {
+			t.Fatalf("expected 'integration' not found in command stdout but found '%s'", string(buf[:n]))
+		}
+
+		testutil.AssertExitsBefore(t, "lspwatch", func() {
+			cmd.Process.Wait()
+		}, 6*time.Second)
+	})
 }

--- a/internal/integration/start_exit_test.go
+++ b/internal/integration/start_exit_test.go
@@ -269,7 +269,7 @@ func TestCommandMode(t *testing.T) {
 
 		testutil.AssertExitsBefore(t, "lspwatch", func() {
 			cmd.Process.Wait()
-		}, 6*time.Second)
+		}, 8*time.Second)
 	})
 
 	t.Run("automatic commmand mode detection", func(t *testing.T) {
@@ -307,6 +307,6 @@ func TestCommandMode(t *testing.T) {
 
 		testutil.AssertExitsBefore(t, "lspwatch", func() {
 			cmd.Process.Wait()
-		}, 6*time.Second)
+		}, 8*time.Second)
 	})
 }

--- a/internal/io/io_test.go
+++ b/internal/io/io_test.go
@@ -1,7 +1,6 @@
 package io
 
 import (
-	"bytes"
 	"io"
 	"strings"
 	"testing"
@@ -52,67 +51,16 @@ func TestStringOrInt(t *testing.T) {
 	})
 }
 
-func TestHeaderCaptureReader(t *testing.T) {
-	t.Run("captures a complete header one Read()", func(t *testing.T) {
-		t.Parallel()
-		headers := "Content-Length: 133\r\nSome-Header: Some-Value\r\n\r\n"
-		reader := io.NopCloser(strings.NewReader(headers + "{\"foo\": \"bar\"}"))
-		headerCaptureReader := NewHeaderCaptureReader(reader)
-		buffer := make([]byte, 1024)
-		headerCaptureReader.Read(buffer)
-
-		if !cmp.Equal(headerCaptureReader.CapturedBytes(), []byte(headers)) {
-			t.Fatalf("expected captured bytes to be %s, but got %s", headers, string(headerCaptureReader.CapturedBytes()))
-		}
-
-		if !bytes.Contains(buffer, []byte(headers)) {
-			t.Fatal("expected Read() to place read bytes in the buffer")
-		}
-	})
-
-	t.Run("captures a complete header (and no more) with multiple Read()s", func(t *testing.T) {
-		t.Parallel()
-		headers := "Content-Length: 133\r\nSome-Header: Some-Value\r\n\r\n"
-		reader := io.NopCloser(strings.NewReader(headers))
-		headerCaptureReader := NewHeaderCaptureReader(reader)
-		buffer1 := make([]byte, 3)
-		buffer2 := make([]byte, 100)
-		headerCaptureReader.Read(buffer1)
-		headerCaptureReader.Read(buffer2)
-
-		if !cmp.Equal(headerCaptureReader.CapturedBytes(), []byte(headers)) {
-			t.Fatalf("expected captured bytes to be %s, but got %s", headers, string(headerCaptureReader.CapturedBytes()))
-		}
-	})
-
-	t.Run("captures a partial header", func(t *testing.T) {
-		t.Parallel()
-		headers := "Content-Length: 133\r\nSome-Header: Some-"
-		reader := io.NopCloser(strings.NewReader(headers))
-		headerCaptureReader := NewHeaderCaptureReader(reader)
-		buffer := make([]byte, 500)
-		headerCaptureReader.Read(buffer)
-
-		if !cmp.Equal(headerCaptureReader.CapturedBytes(), []byte(headers)) {
-			t.Fatalf("expected captured bytes to be %s, but got %s", headers, string(headerCaptureReader.CapturedBytes()))
-		}
-
-		if !bytes.Contains(buffer, []byte(headers)) {
-			t.Fatal("expected Read() to place read bytes in the buffer")
-		}
-	})
-}
-
-func TestLSPMessageReader(t *testing.T) {
+func TestLSPReader(t *testing.T) {
 	t.Run("correct input with extra header", func(t *testing.T) {
 		t.Parallel()
 
 		correctInput := "Content-Length: 133\r\nSome-Header: Some-Value\r\n\r\n{\"jsonrpc\": \"2.0\", \"method\": \"textDocument/highlight\", \"id\": 2, \"params\": {\"textDocument\": {\"uri\": \"file:///Users/someone/test.go\"}}}"
 		reader := io.NopCloser(strings.NewReader(correctInput))
-		lspmr := NewLSPMessageReader(reader)
+		lspReader := NewLSPReader(reader)
 
 		var body LSPClientMessage
-		res := lspmr.ReadLSPMessage(&body)
+		res := lspReader.Read(&body)
 		if res.Err != nil {
 			t.Fatalf("expcted to read correct LSP message, but got error: %v", res.Err)
 		}
@@ -147,8 +95,8 @@ func TestLSPMessageReader(t *testing.T) {
 		reader := io.NopCloser(strings.NewReader(missingContentLengthInput))
 
 		var body LSPClientMessage
-		lspmr := NewLSPMessageReader(reader)
-		res := lspmr.ReadLSPMessage(&body)
+		lspReader := NewLSPReader(reader)
+		res := lspReader.Read(&body)
 		if res.Err == nil {
 			t.Fatalf("expected to get error when Content-Length header is missing, but got nil")
 		}
@@ -162,9 +110,9 @@ func TestLSPMessageReader(t *testing.T) {
 		t.Parallel()
 		input := "Content-Length: not-an-int\r\n\r\n{}"
 		reader := io.NopCloser(strings.NewReader(input))
-		lspmr := NewLSPMessageReader(reader)
+		lspReader := NewLSPReader(reader)
 		var body LSPClientMessage
-		res := lspmr.ReadLSPMessage(&body)
+		res := lspReader.Read(&body)
 		if res.Err == nil {
 			t.Errorf("expected to get error when Content-Length header is not an int, but got nil")
 		}
@@ -174,9 +122,9 @@ func TestLSPMessageReader(t *testing.T) {
 		t.Parallel()
 		input := "Content-Length: 133\r\n\r\n{\"jsonrpc\"/ \"2.0\", \"method\"; \"textDocument/highlight\", \"id\": 2, \"params\": {\"textDocument\": {\"uri\": \"file:///Users/someone/test.go\"}}}"
 		reader := io.NopCloser(strings.NewReader(input))
-		lspmr := NewLSPMessageReader(reader)
+		lspReader := NewLSPReader(reader)
 		var body LSPClientMessage
-		res := lspmr.ReadLSPMessage(&body)
+		res := lspReader.Read(&body)
 		if res.Err == nil {
 			t.Errorf("expected to get error when JSON body is invalid, but got nil")
 		}
@@ -186,15 +134,15 @@ func TestLSPMessageReader(t *testing.T) {
 		t.Parallel()
 		input := "Content-Length: 133\r\nSome-Header: Some-Value\r\n\r\n{\"jsonrpc\": \"2.0\", \"method\": \"textDocument/highlight\", \"id\": 2, \"params\": {\"textDocument\": {\"uri\": \"file:///Users/someone/test.go\"}}}Content-Length: 133\r\nSome-Header: Some-Value\r\n\r\n{\"jsonrpc\": \"2.0\", \"method\": \"textDocument/highlight\", \"id\": 2, \"params\": {\"textDocument\": {\"uri\": \"file:///Users/someone/test.go\"}}}"
 		reader := io.NopCloser(strings.NewReader(input))
-		lspmr := NewLSPMessageReader(reader)
+		lspReader := NewLSPReader(reader)
 
 		var body LSPClientMessage
-		res := lspmr.ReadLSPMessage(&body)
+		res := lspReader.Read(&body)
 		if res.Err != nil {
 			t.Fatalf("expected first read to succeed, but got error '%v'", res.Err)
 		}
 
-		res = lspmr.ReadLSPMessage(&body)
+		res = lspReader.Read(&body)
 		if res.Err != nil {
 			t.Fatalf("expected second read to succeed, but got error '%v'", res.Err)
 		}

--- a/internal/lspwatch.go
+++ b/internal/lspwatch.go
@@ -50,7 +50,7 @@ var availableServerMetrics = map[telemetry.AvailableMetric]telemetry.MetricRegis
 		Kind:        telemetry.Histogram,
 		Name:        "lspwatch.server.rss",
 		Description: "RSS of the language server process",
-		Unit:        "bytes", // TODO: Check if this is correct
+		Unit:        "By",
 	},
 }
 
@@ -248,7 +248,7 @@ func NewLspwatchInstance(
 			return telemetry.TagValue(runtime.GOOS)
 		},
 		telemetry.LanguageServer: func() telemetry.TagValue {
-			// TODO: This is not robust.
+			// TODO: This is not robust?
 			return telemetry.TagValue(filepath.Base(serverCmd.Path))
 		},
 		telemetry.RAM: func() telemetry.TagValue {

--- a/internal/lspwatch.go
+++ b/internal/lspwatch.go
@@ -169,6 +169,7 @@ func NewLspwatchInstance(
 	args []string,
 	configFilePath string,
 	logDir string,
+	mode string,
 ) (LspwatchInstance, error) {
 	logger, logFile, err := lspwatch_io.CreateLogger(logDir, "lspwatch.log")
 	if err != nil {
@@ -253,6 +254,7 @@ func NewLspwatchInstance(
 		os.Stdout,
 		serverStdoutPipe,
 		serverStdinPipe,
+		mode,
 		logger,
 	)
 	if err != nil {


### PR DESCRIPTION
The goal of this PR was to get the VSCode Go language client to work. In this pursuit, some significant changes were made:

* The introduction of `lspwatch` modes: `command` and `proxy`. The correct mode is automatically detected but there are options to set explicitly.

* Dropping `textproto.Reader` in favour of manual header parsing. The existing message parsing setup is buggy in very subtle ways and I don't have time for this whac-a-mole involving 3+ nested readers.

* Stability improvements. Reading EOF causes `lspwatch` to exit.

* Stderr of the language server process now captures in logs.

* Fix broken exit codes.

And now `lspwatch` works reliably in VSCode!