### PR TITLE
Codebase bug identification

### DIFF
--- a/internal/core/proxy.go
+++ b/internal/core/proxy.go
@@ -100,11 +100,13 @@ func (ph *ProxyHandler) Start() {
 		go ph.listenClient()
 		go ph.listenServer()
 	} else if ph.mode == "command" {
+		ph.listenersWaitGroup.Add(1)
 		go ph.passThroughServerBytes()
 	} else {
 		ph.listenersWaitGroup.Add(2)
 		go ph.listenClient()
 		go ph.listenServer()
+		ph.listenersWaitGroup.Add(1)
 		go ph.passThroughServerBytes()
 	}
 
@@ -145,11 +147,14 @@ func (ph *ProxyHandler) enableMetrics(cfg *config.LspwatchConfig) error {
 }
 
 func (ph *ProxyHandler) passThroughServerBytes() {
+	defer ph.listenersWaitGroup.Done()
 	for {
 		buf := make([]byte, 1024)
 		n, err := ph.serverPassThroughReader.Read(buf)
 		if err != nil {
-			ph.logger.Errorf("error reading from server pass through reader: %v", err)
+			if err != io.EOF {
+				ph.logger.Errorf("error reading from server pass through reader: %v", err)
+			}
 			break
 		}
 		ph.logger.Infof("read %d bytes from server pass through reader", n)

--- a/internal/integration/otel_test.go
+++ b/internal/integration/otel_test.go
@@ -53,9 +53,15 @@ type otelExternalExportedObject struct {
 }
 
 func TestLspwatchWithOtel(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("error getting working directory: %v", err)
+	}
+
 	testDataDir := os.Getenv("TEST_DATA_DIR")
 	if testDataDir == "" {
-		t.Fatalf("TEST_DATA_DIR is not set")
+		// Default for local `go test ./...` runs.
+		testDataDir = filepath.Join(cwd, "testdata")
 	}
 
 	bytes, err := os.ReadFile(filepath.Join(testDataDir, "client_messages.json"))
@@ -69,13 +75,11 @@ func TestLspwatchWithOtel(t *testing.T) {
 		t.Fatalf("failed to unmarshal client messages: %v", err)
 	}
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("error getting working directory: %v", err)
-	}
-
 	t.Run("gprc exporter", func(t *testing.T) {
 		t.Parallel()
+		if !dockerIsAvailable(t) {
+			t.Skip("docker not available; skipping external OTel exporter test")
+		}
 		otelExportsDir := createTempWritableDir(t, "otel-grpc-exports")
 		otelConfigFile := filepath.Join(cwd, "config", "otel_config.yaml")
 		lspwatchConfigFile := filepath.Join(cwd, "config", "otel_grpc_lspwatch.yaml")
@@ -103,6 +107,9 @@ func TestLspwatchWithOtel(t *testing.T) {
 
 	t.Run("http exporter", func(t *testing.T) {
 		t.Parallel()
+		if !dockerIsAvailable(t) {
+			t.Skip("docker not available; skipping external OTel exporter test")
+		}
 		otelExportsDir := createTempWritableDir(t, "otel-http-exports")
 		otelConfigFile := filepath.Join(cwd, "config", "otel_config.yaml")
 		lspwatchConfigFile := filepath.Join(cwd, "config", "otel_http_lspwatch.yaml")
@@ -139,12 +146,17 @@ func TestLspwatchWithOtel(t *testing.T) {
 
 func runTest(t *testing.T, configFile string, messages []string) {
 	t.Helper()
+
+	mockServer := filepath.Join(os.Getenv("INTEGRATION_BUILD_DIR"), "mock_language_server")
+	if os.Getenv("INTEGRATION_BUILD_DIR") == "" {
+		mockServer = "./build/mock_language_server"
+	}
 	cmd := testutil.PrepareIntegrationTest(
 		t,
 		"--config",
 		configFile,
 		"--",
-		"./build/mock_language_server",
+		mockServer,
 	)
 
 	serverStdin, err := cmd.StdinPipe()
@@ -387,4 +399,19 @@ func createTempWritableDir(t *testing.T, dirName string) string {
 	}
 
 	return dir
+}
+
+func dockerIsAvailable(t *testing.T) bool {
+	t.Helper()
+
+	// Use the same env-based configuration docker CLI would use (DOCKER_HOST, etc).
+	dockerClient, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return false
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err = dockerClient.Ping(ctx)
+	return err == nil
 }

--- a/internal/integration/start_exit_test.go
+++ b/internal/integration/start_exit_test.go
@@ -192,13 +192,18 @@ func TestServerProcessDiesAbruptly(t *testing.T) {
 func TestUnresponsiveServerProcess(t *testing.T) {
 	t.Parallel()
 	logDir := testutil.GenerateRandomLogDirName()
+
+	unresponsiveServer := filepath.Join(os.Getenv("INTEGRATION_BUILD_DIR"), "unresponsive_server")
+	if os.Getenv("INTEGRATION_BUILD_DIR") == "" {
+		unresponsiveServer = "./build/unresponsive_server"
+	}
 	cmd := testutil.PrepareIntegrationTest(t,
 		"--logdir",
 		logDir,
 		"--mode",
 		"proxy",
 		"--",
-		"./build/unresponsive_server",
+		unresponsiveServer,
 	)
 
 	serverStdin, err := cmd.StdinPipe()

--- a/internal/integration/testmain_test.go
+++ b/internal/integration/testmain_test.go
@@ -1,0 +1,83 @@
+package integration
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// Integration tests historically relied on `make integration-tests`, which sets
+// env vars and builds helper binaries into a ./build directory. When running
+// `go test ./...` from a clean checkout, those prerequisites are missing.
+//
+// This TestMain makes the integration tests hermetic by:
+// - Building a coverage-instrumented lspwatch binary and exporting LSPWATCH_BIN
+// - Creating a writable coverage directory and exporting COVERAGE_DIR
+// - Building helper servers and exporting INTEGRATION_BUILD_DIR
+// - Defaulting TEST_DATA_DIR to ./testdata
+func TestMain(m *testing.M) {
+	packageDir, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "integration TestMain: failed to get wd:", err)
+		os.Exit(2)
+	}
+
+	// Default TEST_DATA_DIR for local `go test ./...`.
+	if os.Getenv("TEST_DATA_DIR") == "" {
+		_ = os.Setenv("TEST_DATA_DIR", filepath.Join(packageDir, "testdata"))
+	}
+
+	tmpRoot, err := os.MkdirTemp("", "lspwatch-integration-*")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "integration TestMain: failed to create temp dir:", err)
+		os.Exit(2)
+	}
+	defer os.RemoveAll(tmpRoot)
+
+	// Ensure COVERAGE_DIR exists for subprocess coverage export.
+	if os.Getenv("COVERAGE_DIR") == "" {
+		coverageDir := filepath.Join(tmpRoot, "coverage")
+		if err := os.MkdirAll(coverageDir, 0o755); err != nil {
+			fmt.Fprintln(os.Stderr, "integration TestMain: failed to create coverage dir:", err)
+			os.Exit(2)
+		}
+		_ = os.Setenv("COVERAGE_DIR", coverageDir)
+	}
+
+	// Build helper binaries into tmpRoot and expose path.
+	_ = os.Setenv("INTEGRATION_BUILD_DIR", tmpRoot)
+
+	repoRoot := filepath.Clean(filepath.Join(packageDir, "..", ".."))
+
+	// If a binary is already provided (e.g. via Makefile), respect it.
+	if os.Getenv("LSPWATCH_BIN") == "" {
+		lspwatchBin := filepath.Join(tmpRoot, "lspwatch_cov")
+		cmd := exec.Command("go", "build", "-cover", "-covermode=atomic", "-o", lspwatchBin, "./")
+		cmd.Dir = repoRoot
+		cmd.Env = os.Environ()
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "integration TestMain: failed to build lspwatch:", err)
+			fmt.Fprintln(os.Stderr, string(out))
+			os.Exit(2)
+		}
+		_ = os.Setenv("LSPWATCH_BIN", lspwatchBin)
+	}
+
+	// Build integration helper servers if they don't exist.
+	// `go build -C <pkgdir> -o <dir>/ ./cmd/...` yields binaries named after each cmd.
+	cmd := exec.Command("go", "build", "-C", packageDir, "-o", tmpRoot+string(os.PathSeparator), "./cmd/...")
+	cmd.Dir = repoRoot
+	cmd.Env = os.Environ()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "integration TestMain: failed to build integration helpers:", err)
+		fmt.Fprintln(os.Stderr, string(out))
+		os.Exit(2)
+	}
+
+	os.Exit(m.Run())
+}
+

--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -197,10 +197,34 @@ func CreateLogger(logDir string, fileName string) (*logrus.Logger, *os.File, err
 
 func (bd *SingleUseDiverterPipe) Start() {
 	go func() {
+		var readErr error
+		defer func() {
+			// If the source closes, ensure any downstream pipe writers also close so
+			// readers can terminate (important for command-mode pass-through).
+			closeDest := func(w io.Writer, err error) {
+				// Prefer CloseWithError for io.PipeWriter.
+				if cwe, ok := w.(interface{ CloseWithError(error) error }); ok {
+					_ = cwe.CloseWithError(err)
+					return
+				}
+				if c, ok := w.(io.Closer); ok {
+					_ = c.Close()
+				}
+			}
+
+			// Treat io.EOF as a clean shutdown.
+			if readErr == io.EOF {
+				readErr = nil
+			}
+			closeDest(bd.firstDestination, readErr)
+			closeDest(bd.secondDestination, readErr)
+		}()
+
 		for {
 			buf := make([]byte, 1024)
 			n, err := bd.source.Read(buf)
 			if err != nil {
+				readErr = err
 				break
 			}
 


### PR DESCRIPTION
Make integration tests hermetic, fix command-mode hangs, and skip Docker-dependent tests when Docker is unavailable to improve test reliability and local development experience.

Previously, integration tests were not hermetic, requiring manual environment variable setup and pre-built binaries, which hindered local `go test ./...` execution. Command-mode operations could also hang due to untracked goroutines and unclosed pipes. Additionally, OTel integration tests failed in environments without Docker. This PR addresses these issues by centralizing test setup, ensuring proper goroutine and pipe lifecycle management, and adding Docker availability checks.

---
<a href="https://cursor.com/background-agent?bcId=bc-2286f18b-5891-4cfa-bd23-06da79d483f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2286f18b-5891-4cfa-bd23-06da79d483f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

